### PR TITLE
Fix missing #( when instantiating a module that contains parameters i…

### DIFF
--- a/eclipse/plugins/it.mdc.tool/src/it/mdc/tool/core/platformComposer/TestBenchPrinterGeneric.xtend
+++ b/eclipse/plugins/it.mdc.tool/src/it/mdc/tool/core/platformComposer/TestBenchPrinterGeneric.xtend
@@ -188,7 +188,7 @@ class TestBenchPrinterGeneric {
 	def printDUT(List<SboxLut> luts) {
 		
 		'''
-		multi_dataflow «IF !network.variables.empty»
+		multi_dataflow «IF !network.variables.empty» # (
 			«FOR netVar : network.variables SEPARATOR ","»
 			.«netVar.name»(«netVar.name»)
 			«ENDFOR»


### PR DESCRIPTION
There was a small problem with the generated tb when using static parameters. Now it works.